### PR TITLE
Fix incorrect month in generated header

### DIFF
--- a/src/common/utils/generate-ppf.util.ts
+++ b/src/common/utils/generate-ppf.util.ts
@@ -30,7 +30,7 @@ const generateHeader = (member: string) => {
   const todayString = `${today.getMonth() + 1}/${today.getDate()}`;
 
   const lastWeek = new Date(new Date().setDate(today.getDate() - 7));
-  const lastWeekString = `${lastWeek.getMonth()}/${lastWeek.getDate()}`;
+  const lastWeekString = `${lastWeek.getMonth() + 1}/${lastWeek.getDate()}`;
 
   return `# ${member}'s PPF (${lastWeekString}-${todayString})\n`;
 };


### PR DESCRIPTION
This fixes the incorrect month being returned in the header when generating PPF's.

Currently, `generateHeader` returns the incorrect month in `lastWeekString` because `getMonth()` is zero-indexed.